### PR TITLE
Increase target tick duration

### DIFF
--- a/src/public_settings.h
+++ b/src/public_settings.h
@@ -23,7 +23,7 @@
 // Number of ticks from prior epoch that are kept after seamless epoch transition. These can be requested after transition.
 #define TICKS_TO_KEEP_FROM_PRIOR_EPOCH 100
 
-#define TARGET_TICK_DURATION 1000
+#define TARGET_TICK_DURATION 3000
 #define TRANSACTION_SPARSENESS 1
 
 // Below are 2 variables that are used for auto-F5 feature:


### PR DESCRIPTION
The delay function did not work due to bugs. Now the delay function works and tick time should decrease.